### PR TITLE
Updated dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # vae
 Variational Autoencoder or Deep Latent Gaussian Model demo
 
-Blog post: https://jaan.io/unreasonable-confusion/
+Blog post: https://jaan.io/what-is-variational-autoencoder-vae/


### PR DESCRIPTION
You may also want to update the repo's description, which still refers to the old link (https://jaan.io/unreasonable-confusion/)